### PR TITLE
Add mirrored name as new result type

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,13 +34,15 @@ app.get("/coolify", (request, response) => {
   names.unshift(cool_names[2])
   names.unshift(cool_names[3])
   names.unshift(cool_names[4])
+  names.unshift(cool_names[5])
   response.setHeader('Content-Type', 'application/json')
   response.json({
     cool_names_symbolic: cool_names[0],
     cool_name_alphanum: cool_names[1],
     cool_name_rounded: cool_names[2],
     cool_name_square: cool_names[3],
-    cool_name_round_alphanum : cool_names[4]
+    cool_name_round_alphanum : cool_names[4],
+    cool_name_mirrored : cool_names[5],
   })
 })
 

--- a/services/coolifyService.js
+++ b/services/coolifyService.js
@@ -102,7 +102,8 @@ coolify.alphaNumericName = function(name) {
 		let cool_name_round_alphanum = cool_name_rounded.slice(0, 1) + cool_name_alphanum.slice(1, name.length - 1)
 												+ cool_name_rounded.slice(name.length - 1, name.length);
    		let cool_name_symbolic = name.allReplace(coolifyDicts.symbolic);
-     return [cool_name_alphanum, cool_name_rounded, cool_name_square, cool_name_round_alphanum, cool_name_symbolic];
+		let cool_name_mirrored = '‮' + name;
+     return [cool_name_alphanum, cool_name_rounded, cool_name_square, cool_name_round_alphanum, cool_name_symbolic, cool_name_mirrored];
   } else {
     return false;
   }


### PR DESCRIPTION
Please note that while the text content is technically correct, the unicode right to left override character makes the code text rendered mirrored as well. So while the code looks like is syntactically incorrect, it is not. It works fine on the webpage and JSON, even when the browser renders the JSON wrong.

![image](https://user-images.githubusercontent.com/93181/46400008-9ee89880-c6f9-11e8-8951-47f1e2ef6341.png)

![image](https://user-images.githubusercontent.com/93181/46399998-95f7c700-c6f9-11e8-904a-70b513691233.png)

![image](https://user-images.githubusercontent.com/93181/46400055-bb84d080-c6f9-11e8-9d00-8723b98f038a.png)
