### PR TITLE
Fix js formatting in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ app.use(express.static('public'))
 
 // http://expressjs.com/en/starter/basic-routing.html
 app.get("/", (request, response) => {
-  response.sendFile(__dirname + '/views/index.html')
+	response.sendFile(__dirname + '/views/index.html')
 })
 
 // Simple in-memory store
@@ -23,35 +23,35 @@ const names = [
 ]
 
 app.get("/names", (request, response) => {
-  response.send(names)
+	response.send(names)
 })
 
 // could also use the POST body instead of query string: http://expressjs.com/en/api.html#req.body
 app.get("/coolify", (request, response) => {
-  let cool_names = coolify.alphaNumericName(request.query.name)
-  names.unshift(cool_names[0])
-  names.unshift(cool_names[1])
-  names.unshift(cool_names[2])
-  names.unshift(cool_names[3])
-  names.unshift(cool_names[4])
-  names.unshift(cool_names[5])
-  names.unshift(cool_names[6])
+	let cool_names = coolify.alphaNumericName(request.query.name)
+	names.unshift(cool_names[0])
+	names.unshift(cool_names[1])
+	names.unshift(cool_names[2])
+	names.unshift(cool_names[3])
+	names.unshift(cool_names[4])
+	names.unshift(cool_names[5])
+	names.unshift(cool_names[6])
 	names.unshift(cool_names[7])
 
-  response.setHeader('Content-Type', 'application/json')
-  response.json({
-    cool_names_symbolic: cool_names[0],
-    cool_name_alphanum: cool_names[1],
-    cool_name_rounded: cool_names[2],
-    cool_name_square: cool_names[3],
-    cool_name_round_alphanum : cool_names[4],
-    cool_name_mirrored : cool_names[5],
-    cool_name_xabovebelow: cool_names[6],
-		cool_name_emoji : cool_names[7]
-  })
+	response.setHeader('Content-Type', 'application/json')
+	response.json({
+		cool_names_symbolic: cool_names[0],
+		cool_name_alphanum: cool_names[1],
+		cool_name_rounded: cool_names[2],
+		cool_name_square: cool_names[3],
+		cool_name_round_alphanum: cool_names[4],
+		cool_name_mirrored: cool_names[5],
+		cool_name_xabovebelow: cool_names[6],
+		cool_name_emoji: cool_names[7]
+	})
 })
 
 // listen for requests :)
 const listener = app.listen(3000, () => {
-  console.log(`Your app is listening on port 3000`)
+	console.log(`Your app is listening on port 3000`)
 })


### PR DESCRIPTION
I missed the `server.js` in the last PR.

---

Indentation should be tabs as per .editorconfig

Use consistent spacing
